### PR TITLE
Incorrect status is shown when ETA end date has already passed

### DIFF
--- a/src/components/05_VinDetailsView.vue
+++ b/src/components/05_VinDetailsView.vue
@@ -259,7 +259,7 @@ export default {
     },
     getDaysToDelivery (etaEndDate) {
       const deliveryDate = new Date(etaEndDate + 'T00:00:00')
-      const timeDiff = Math.abs(deliveryDate.getTime() - this.today.getTime())
+      const timeDiff = deliveryDate.getTime() - this.today.getTime()
       const diffDays = Math.ceil(timeDiff / (1000 * 3600 * 24))
       return diffDays
     },


### PR DESCRIPTION
Due to `getDaysToDelivery` using `Math.abs` when calculating the time difference, the status shows an incorrectly increasing value if the delivery has gone beyond the ETA end date (e.g. for a delivery that should have happened two days ago on September 13th, it currently shows "is estimated to be delivered to dealer in 2 days."

This change removes the call to `Math.abs`, and the resulting status for the above now simply shows as "In Transit".